### PR TITLE
run sketch in an iframe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/public/_sketch.html
+++ b/public/_sketch.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+  <head>
+    <script language="javascript" type="text/javascript" src="js/p5.js"></script>
+    <style>
+        html, body {
+          overflow: hidden;
+          margin: 0;
+          padding: 0;
+          background:white;
+        }
+    </style>
+  </head>
+  <body>
+  </body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -1,44 +1,46 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  	<meta charset="UTF-8">
-  	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
- 	<title>Editor</title>
-	<link rel="stylesheet" type="text/css" href="css/style.css">
-  	<script language="javascript" type="text/javascript" src="js/p5.js"></script>
-  	<script src="js/jquery-1.11.3.min.js"></script>
-	<script src="js/limby-resize/canvas_resize.js"></script>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <title>p5js Sandbox</title>
+  <link rel="stylesheet" type="text/css" href="css/style.css">
+    <script language="javascript" type="text/javascript" src="js/p5.js"></script>
+    <script src="js/jquery-1.11.3.min.js"></script>
+    <script src="js/limby-resize/canvas_resize.js"></script>
 </head>
 <body>
-	
+
 
 <div id="main">
-	<div id="sketchPane">
-		<div id="myP5">
-		</div>
-	</div>
-    
-    <div id="editorPane">
-		<div id="editorControl">
-			<div id="editorControlNav">
-				<ul id="navlist">
-				<li><a id="showEditor" href="#" onclick="showEditor();">Show</a></li>
-				<li><a id="hideEditor" href="#" onclick="hideEditor();">Hide</a></li>
-				<li><a id="playEditor" href="#" onclick="playEditor();">Play</a></li>
-				<li><a id="saveSketch" href="#" onclick="saveCanvas2();">Save</a></li>
-				<li><a id="browseSketches" href="/browse">Browse</a></li>
-				<li><a id="randomSketch" href="#" onclick="requestRandomSketch();">Random</a></li>
-				<li><a id="linkGithub" href="https://github.com/genekogan/p5js-sandbox">Source</a></li>
-				<div id="savingNote">saving sketch! don't reload...</div>
-				</ul>	
-			</div>
-		</div>
+  <div id="sketchPane">
+    <!-- sandbox="allow-same-origin allow-scripts allow-popups allow-forms" -->
+    <iframe id="sketchFrame"
+src="_sketch.html" width="100%" height="1000">
+    </iframe>
+  </div>
 
-    	<pre id="editor">
-		</pre>
-
+  
+  <div id="editorPane">
+  <div id="editorControl">
+    <div id="editorControlNav">
+      <ul id="navlist">
+      <li><a id="showEditor" href="#" onclick="showEditor();">Show</a></li>
+      <li><a id="hideEditor" href="#" onclick="hideEditor();">Hide</a></li>
+      <li><a id="playEditor" href="#" onclick="playCode();">Play</a></li>
+      <li><a id="saveSketch" href="#" onclick="saveCanvas2();">Save</a></li>
+      <li><a id="browseSketches" href="/browse">Browse</a></li>
+      <li><a id="randomSketch" href="#" onclick="requestRandomSketch();">Random</a></li>
+      <li><a id="linkGithub" href="https://github.com/genekogan/p5js-sandbox">Source</a></li>
+      <div id="savingNote">saving sketch! don't reload...</div>
+      </ul> 
     </div>
+  </div>
 
+    <pre id="editor">
+  </pre>
+
+  </div>
 
 </div>
 
@@ -47,7 +49,7 @@
 <script src="js/ace/ace.js" type="text/javascript" charset="utf-8"></script>
 <script src="js/client.js" type="text/javascript" charset="utf-8"></script>
 <script>
-	startMain();
+  startMain();
 </script>
 
 </body>

--- a/public/js/client.js
+++ b/public/js/client.js
@@ -1,14 +1,12 @@
-var p5functions = ['preload','setup','draw','keyPressed','keyReleased','keyTyped','mouseMoved','mouseDragged','mousePressed','mouseReleased','mouseClicked','touchStarted','touchMoved','touchEnded'];
-// var p5constants = ['ARROW','CROSS','HAND','MOVE','TEXT','WAIT','HALF_PI','PI','QUARTER_PI','TAU','TWO_PI','DEGREES','RADIANS','CORNER','CORNERS','RADIUS','RIGHT','LEFT','CENTER','TOP','BOTTOM','BASELINE','POINTS','LINES','TRIANGLES','TRIANGLE_FAN','TRIANGLE_STRIP','QUADS','QUAD_STRIP','CLOSE','OPEN','CHORD','PIE','PROJECT','SQUARE','ROUND','BEVEL','MITER','RGB','HSB','AUTO','ALT','BACKSPACE','CONTROL','DELETE','DOWN_ARROW','ENTER','ESCAPE','LEFT_ARROW','OPTION','RETURN','RIGHT_ARROW','SHIFT','TAB','UP_ARROW','BLEND','ADD','DARKEST','LIGHTEST','DIFFERENCE','EXCLUSION','MULTIPLY','SCREEN','REPLACE','OVERLAY','HARD_LIGHT','SOFT_LIGHT','DODGE','BURN','THRESHOLD','GRAY','OPAQUE','INVERT','POSTERIZE','DILATE','ERODE','BLUR','NORMAL','ITALIC','BOLD','LINEAR','QUADRATIC','BEZIER','CURVE'];
-// var p5values =  ['frameCount','focused','displayWidth','displayHeight','windowWidth','windowHeight','windowResized','width','height','deviceOrientation','accelerationX','accelerationY','accelerationZ','pAccelerationX','pAccelerationY','pAccelerationZ','keyIsPressed','key','keyCode','mouseX','mouseY','pmouseX','pmouseY','winMouseX','winMouseY','pwinMouseX','pwinMouseY','mouseButton','mouseIsPressed','pixels[]','touchX','touchY','ptouchX','ptouchY','touches[]','touchIsDown']
-// var p5methods = ['alpha','blue','brightness','color','green','hue','lerpColor','red','saturation','background','clear','colorMode','fill','noFill','noStroke','stroke','remove','noLoop','loop','push','pop','redraw','append','arrayCopy','concat','reverse','shorten','shuffle','sort','splice','subset','float','int','join','match','matchAll','nf','nfc','nfp','nfs','split','splitTokens','trim','save','cursor','frameRate','noCursor','fullscreen','devicePixelScaling','getURL','getURLPath','getURLParams','createImage','loadImage','image','tint','noTint','imageMode','blend','copy','filter','get','loadPixels','set','updatePixels','setMoveThreshold','onDeviceMove','onDeviceTurn','loadJSON','loadStrings','loadTable','loadXML','httpGet','httpPost','httpDo','keyIsDown','mouseWheel','day','hour','minute','millis','month','second','year','createVector','abs','ceil','constrain','dist','exp','floor','lerp','log','mag','map','max','min','norm','pow','sq','sqrt','noise','noiseDetail','noiseSeed','randomSeed','random','randomGaussian','acos','asin','atan','atan2','cos','sin','tan','degrees','radians','angleMode','print','createCanvas','resizeCanvas','noCanvas','createGraphics','blendMode','arc','ellipse','line','point','quad','rect','triangle','ellipseMode','noSmooth','rectMode','smooth','strokeCap','strokeJoin','strokeWeight','bezier','bezierPoint','bezierTangent','curve','curveTightness','curvePoint','curveTangent','beginContour','beginShape','bezierVertex','curveVertex','endContour','endShape','quadraticVertex','vertex','applyMatrix','resetMatrix','rotate','scale','shearX','shearY','translate','textAlign','textLeading','textSize','textStyle','textWidth','text','textFont'];
-
 var host;
 
 var editor;
 var lastPlayedCodeText;
 var activeSketch;
 
+var settings = {
+	"fullScreen" : true,
+}
 
 function browseSketches() {
 	var socket = io.connect(host);
@@ -42,58 +40,38 @@ var saveSketchToServer = function(codeText, imageText){
 
 // adapted from p5js.org, originally by Lauren McCarthy
 // https://github.com/processing/p5.js-website/blob/master/js/render.js
-var playCode = function(code) {
-  var runnable = code;
-  var _p5 = p5;
+function initCode() {
+  var ed = editor;
 
-  var s = function( p ) {
-    if (runnable.indexOf('setup()') === -1 && runnable.indexOf('draw()') === -1){
-      p.setup = function() {
-        p.createCanvas(window.innerWidth, window.innerHeight);
-        with (p) {
-          eval(runnable);
-        }
-      }
-    }
-    else {
+  // tell exampleFrame to reset code every time it loads
+	document.getElementById('sketchFrame').onload = function() {
+		var code = ed.getValue();
+		code += '\n new p5();\n'
 
-      with (p) {
-        eval(runnable);
-      }
+		if (settings.fullScreen) {
+			// to do: check to see if setup exists,
+			// and if createCanvas exists,
+			// if not make it windowWidth, windowHeight
+			code += '\n  function windowResized() {\n' +
+							'resizeCanvas(windowWidth, windowHeight);\n'+
+							'}';
+		}
 
-      var fxns = p5functions;
-      fxns.forEach(function(f) { 
-        if (runnable.indexOf(f) !== -1) {
-          with (p) {
-            p[f] = eval(f);
-          }
-        }
-      });
+		var userScript = $('#sketchFrame')[0].contentWindow.document.createElement('script');
+		userScript.type = 'text/javascript';
+		userScript.text = code;
+		userScript.async = false;
+		$('#sketchFrame')[0].contentWindow.document.body.appendChild(userScript);
+	};
 
-      if (typeof p.setup === 'undefined') {
-      	console.log('no setup');
-        p.setup = function() {
-          p.createCanvas(window.innerWidth, window.innerHeight);
-        }
-      }
-    }
-  };
+	playCode();
 
-  // instantiate the p5 instance
-  var myp5 = new _p5(s, myP5);
+}
 
-  setTimeout(function() {
-    if ( typeof(activeSketch !== 'undefined') ) {
-      activeSketch.remove();
-    }
-    activeSketch = myp5;
-  }, 100);
-
+var playCode = function() {
+	$('#sketchFrame').attr('src', $('#sketchFrame').attr('src'));
 };
 
-function playEditor() {
-	playCode(editor.getValue());
-};
 
 function toggleSaving(isSaving) {
 	if (isSaving) {
@@ -111,16 +89,16 @@ function saveCanvas2() {
 	image.src = document.getElementById("defaultCanvas").toDataURL('image/png', 0.8);
     image.onload = function () {
 		var canvas = document.createElement('canvas');
-	  	canvas.width = image.width;
-	  	canvas.height = image.height;
-	  	canvas.getContext('2d').drawImage(image, 0, 0, image.width, image.height);
-	  	var resized = document.createElement('canvas');
-	  	resized.width = 240;
-	  	resized.height = 240 * image.height / image.width;
-	  	canvasResize(canvas, resized, function(){
-	        var thumbnail = resized.toDataURL("image/jpeg", 0.75);
-	        saveSketchToServer(lastPlayedCodeText, thumbnail);
-	     });		
+			canvas.width = image.width;
+			canvas.height = image.height;
+			canvas.getContext('2d').drawImage(image, 0, 0, image.width, image.height);
+			var resized = document.createElement('canvas');
+			resized.width = 240;
+			resized.height = 240 * image.height / image.width;
+			canvasResize(canvas, resized, function(){
+				var thumbnail = resized.toDataURL("image/jpeg", 0.75);
+				saveSketchToServer(lastPlayedCodeText, thumbnail);
+			});
 	};
 };
 
@@ -152,18 +130,19 @@ function editorWriteDefaultCode() {
 	editor.setValue(defaultCode);
 };
 
+
 function startMain() {
 	editor = ace.edit("editor");
 	editor.setTheme("ace/theme/twilight");
 	editor.getSession().setMode("ace/mode/javascript");
-	activeSketch = new p5('', myP5);
 
 	var socket = io.connect(host);
+	initCode();
 
 	// did we receive a sketch?
 	socket.on('sketchData', function (data) {
+		console.log('sketch data');
 		editor.setValue(data.codeText);	// insert code into ace editor
-		playCode(data.codeText);
 	});
 	socket.on('setupDefaultSketch', function () {
 		editorWriteDefaultCode();
@@ -199,7 +178,7 @@ function startBrowse() {
 	});
 };
 
-host = location.origin;	
+host = location.origin;
 
 window.onload = function() {
 	showEditor();

--- a/server.js
+++ b/server.js
@@ -8,54 +8,66 @@ var mongodb = require('mongodb');
 var uri = 'mongodb://heroku_app37049842:dolsgo69sgqu0kupj60kklues5@ds053310.mongolab.com:53310/heroku_app37049842';
 
 var saveSketch = function(codeText, thumbnail) {
-	mongodb.MongoClient.connect(uri, function(err, db) {
-	  	if(err) throw err;
-	  	var sketchData = {codeText: codeText, thumbnail: thumbnail};
-	    db.collection('sketches').insert(sketchData, function(err, result) {
-	  		if(err) throw err;
-      		console.log("Saved sketch to sketches collection");
-  		});
-  	});
+  mongodb.MongoClient.connect(uri, function(err, db) {
+    if(err) {
+      console.log( 'Error: ' + err.message );
+      return;
+    }
+    var sketchData = {codeText: codeText, thumbnail: thumbnail};
+    db.collection('sketches').insert(sketchData, function(err, result) {
+      if(err) throw err;
+        console.log("Saved sketch to sketches collection");
+    });
+  });
 };
 
 var sendSketchToClient = function(socket, id){
-	mongodb.MongoClient.connect(uri, function(err, db) {
-    	if(err) throw err;
-    	db.collection('sketches').find({_id: mongodb.ObjectId(id)}).toArray(function (err, docs) {
-      		if(err) throw err;
-      		docs.forEach(function (doc) {
-      			socket.emit('sketchData', { _id:doc._id, codeText:doc['codeText'], thumbnail:doc['thumbnail'] });
-      		});
-    	});
-	});
-};  
+  mongodb.MongoClient.connect(uri, function(err, db) {
+    if(err) {
+      console.log( 'Error: ' + err.message );
+      return;
+    }
+    db.collection('sketches').find({_id: mongodb.ObjectId(id)}).toArray(function (err, docs) {
+        if(err) throw err;
+        docs.forEach(function (doc) {
+          socket.emit('sketchData', { _id:doc._id, codeText:doc['codeText'], thumbnail:doc['thumbnail'] });
+        });
+    });
+  });
+};
 
 var sendRandomSketchToClient = function(socket){
-  	mongodb.MongoClient.connect(uri, function(err, db) {
-    	if(err) throw err;
-    	db.collection('sketches').find().toArray(function (err, docs) {
-    		if(err) throw err;
-	  		if (docs.length > 0) {
-      			var idxRandom = Math.floor(docs.length * Math.random(1));
-      			socket.emit('sketchData', { _id:docs[idxRandom]._id, codeText:docs[idxRandom]['codeText'], thumbnail:docs[idxRandom]['thumbnail'] });
-			} else {
-				socket.emit('setupDefaultSketch');
-			}
-    	});
-  	});
-};  
+  mongodb.MongoClient.connect(uri, function(err, db) {
+    if(err) {
+      console.log( 'Error: ' + err.message );
+      return;
+    }
+    db.collection('sketches').find().toArray(function (err, docs) {
+      if(err) throw err;
+      if (docs.length > 0) {
+          var idxRandom = Math.floor(docs.length * Math.random(1));
+          socket.emit('sketchData', { _id:docs[idxRandom]._id, codeText:docs[idxRandom]['codeText'], thumbnail:docs[idxRandom]['thumbnail'] });
+    } else {
+      socket.emit('setupDefaultSketch');
+    }
+    });
+  });
+};
 
 var sendSketchesData = function(socket){
-	mongodb.MongoClient.connect(uri, function(err, db) {
-  		if(err) throw err;
-  		db.collection('sketches').find().toArray(function (err, docs) {
-  			if(err) throw err;
-  			docs.forEach(function (doc) {
-        		socket.emit('sketchesData', { _id:doc._id, thumbnail:doc['thumbnail'] });
-    		});
-    	});
-  	});
-};  
+  mongodb.MongoClient.connect(uri, function(err, db) {
+    if(err) {
+      console.log( 'Error: ' + err.message );
+      return;
+    }
+    db.collection('sketches').find().toArray(function (err, docs) {
+      if(err) throw err;
+      docs.forEach(function (doc) {
+          socket.emit('sketchesData', { _id:doc._id, thumbnail:doc['thumbnail'] });
+      });
+    });
+  });
+};
 
 //app.set('port', (process.env.PORT || 5000));
 app.use(express.static(__dirname + '/public'));


### PR DESCRIPTION
- run sketch by injecting a script onto an iframe, similar to p5js.org examples. The iframe reloads when code is updated.
  - maintaining a list of p5 functions is no longer necessary
  - activeSketch is no longer necessary / the sketch is disposed of automatically when page reloads
- add _sketch.html, a template for sketches that gets loaded as an iframe
- add gitignore
- in server.js, changed the way mongodb connect errors are handled so it logs errors but can continue running
